### PR TITLE
Add support for signed developer mode CrOS devices, improve error messages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -36,33 +36,48 @@ fi
 
 # detect operating system and install
 
-if [ -f "/usr/bin/old_bins/chromeos-tpm-recovery" ]; then # Chrome OS
-    sudo mount -o remount,rw /
+if [ -x "/usr/bin/crossystem" ]; then # Chrome OS
+    sudo mount -o remount,rw / 2>/dev/null
     if [ "$?" -ne "0" ]; then
-        echo "[INFO] It appears your Chrome OS device is not rooted. Having root privliges is needed to install ADB and Fastboot."
-        echo "[INFO] Make sure your device is in Developer Mode and type this into the command line:"
-        echo "[INFO] sudo /usr/share/vboot/bin/make_dev_ssd.sh --force --remove_rootfs_verification"
-        echo " "
-        exit 0
+        if [ -x /usr/local/bin ]; then
+            ADB=/usr/local/bin/adb
+            FASTBOOT=/usr/local/bin/fastboot
+            UDEV=
+        fi
+        /usr/bin/crossystem 'mainfw_type?developer'
     fi
-    if [ "$(arch)" == "i386" ] || [ "$(arch)" == "i486" ] || [ "$(arch)" == "i586" ] || [ "$(arch)" == "amd64" ] || [ "$(arch)" == "x86_64" ] || [ "$(arch)" == "i686" ]; then # Chrome OS on Intel x86/x86_64 CPU
+    if [ "$?" -ne "0" ]; then
+        
+        echo "[INFO] It appears your Chromium/Chrome OS device is not in developer mode.
+        echo "[INFO] Developer mode is needed to install ADB and Fastboot."
+        echo "[INFO] Make sure your device is booted in developer mode."
+        echo "[INFO] To set up developer tools, use this command: sudo dev_install"
+        echo " "
+        exit 1
+    fi
+    case "$(arch)" in
+    i*86|amd64|x86_64)
         echo "[INFO] Downloading ADB for Chrome OS [Intel CPU]..."
         sudo curl -s -o $ADB "http://github.com/corbindavenport/nexus-tools/blob/master/bin/linux-i386-adb?raw=true" -LOk
         echo "[INFO] Downloading Fastboot for Chrome [Intel CPU]..."
         sudo curl -s -o $FASTBOOT "http://github.com/corbindavenport/nexus-tools/blob/master/bin/linux-i386-fastboot?raw=true" -LOk
-    elif [ "$(arch)" == "arm" ] || [ "$(arch)" == "armv71" ]; then # Chrome on ARM CPU
+        ;;
+    arm|armv*)
         echo "[WARN] The ADB binaries for ARM are out of date, and do not work on Android 4.2.2+"
         echo "[INFO] Downloading ADB for Chrome OS [ARM CPU]..."
         sudo curl -s -o $ADB "http://github.com/corbindavenport/nexus-tools/blob/master/bin/linux-arm-adb?raw=true" -LOk
         echo "[INFO] Downloading Fastboot for Chrome OS [ARM CPU]..."
         sudo curl -s -o $FASTBOOT "http://github.com/corbindavenport/nexus-tools/blob/master/bin/linux-arm-fastboot?raw=true" -LOk
-    else
+        ;;
+    *)
     	echo "[EROR] Your CPU platform could not be detected. Now exiting."
     	echo " "
-    	exit 0
-    fi
+    	exit 1
+    esac
     echo "[INFO] Downloading udev list..."
-    sudo curl -s -o $UDEV "http://github.com/corbindavenport/nexus-tools/blob/master/udev.txt" -LOk
+    if [ -n "$UDEV" ]; then
+        sudo curl -s -o $UDEV "http://github.com/corbindavenport/nexus-tools/blob/master/udev.txt" -LOk
+    fi
     echo "[INFO] Making ADB and Fastboot executable..."
     sudo chmod +x $ADB
     sudo chmod +x $FASTBOOT
@@ -113,5 +128,5 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then # Generic Linux
 else
     echo "[EROR] Your operating system could not be detected. Now exiting."
     echo " "
-    exit 0
+    exit 1
 fi


### PR DESCRIPTION
What it says on the tin. :) We skip the udev rules if a Chromium OS system can't remount its root read-write (normal for signed boot under developer mode), but has /usr/local available for executables.
