### PR TITLE
remove contradictory option in curl. check sudo in uninstall

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,15 +40,15 @@ fi
 
 if [ "$OS" == "Darwin" ]; then # Mac OS X
     echo "[INFO] Downloading ADB for Mac OS X..."
-    sudo curl -s -o $ADB "http://github.com/corbindavenport/nexus-tools/raw/master/bin/mac-adb" -LOk
+    sudo curl -o $ADB "http://github.com/corbindavenport/nexus-tools/raw/master/bin/mac-adb" -Lks
     echo "[INFO] Downloading Fastboot for Mac OS X..."
-    sudo curl -s -o $FASTBOOT "http://github.com/corbindavenport/nexus-tools/raw/master/bin/mac-fastboot" -LOk
+    sudo curl -o $FASTBOOT "http://github.com/corbindavenport/nexus-tools/raw/master/bin/mac-fastboot" -Lks
     echo "[INFO] Downloading udev list..."
     if [ -n "$UDEV" ]; then
         if [ ! -d /etc/udev/rules.d/ ]; then
             sudo mkdir -p /etc/udev/rules.d/
         fi
-        sudo curl -s -o $UDEV "http://github.com/corbindavenport/nexus-tools/raw/master/udev.txt" -LOk
+        sudo curl -Lks -o $UDEV "http://github.com/corbindavenport/nexus-tools/raw/master/udev.txt" 
         sudo chmod 644 $UDEV
         sudo chown root. $UDEV 2>/dev/null
         sudo service udev restart 2>/dev/null
@@ -64,15 +64,15 @@ if [ "$OS" == "Darwin" ]; then # Mac OS X
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then # Generic Linux
     if [ "$ARCH" == "i386" ] || [ "$ARCH" == "i486" ] || [ "$ARCH" == "i586" ] || [ "$ARCH" == "amd64" ] || [ "$ARCH" == "x86_64" ] || [ "$ARCH" == "i686" ]; then # Linux on Intel x86/x86_64 CPU
         echo "[INFO] Downloading ADB for Linux [Intel CPU]..."
-        sudo curl -s -o $ADB "http://github.com/corbindavenport/nexus-tools/raw/master/bin/linux-i386-adb" -LOk
+        sudo curl -o $ADB "http://github.com/corbindavenport/nexus-tools/raw/master/bin/linux-i386-adb" -Lks
         echo "[INFO] Downloading Fastboot for Linux [Intel CPU]..."
-        sudo curl -s -o $FASTBOOT "http://github.com/corbindavenport/nexus-tools/raw/master/bin/linux-i386-fastboot" -LOk
+        sudo curl -o $FASTBOOT "http://github.com/corbindavenport/nexus-tools/raw/master/bin/linux-i386-fastboot" -Lks
     elif [ "$ARCH" == "arm" ] || [ "$ARCH" == "armv6l" ]; then # Linux on ARM CPU
         echo "[WARN] The ADB binaries for ARM are out of date, and do not work on Android 4.2.2+"
         echo "[INFO] Downloading ADB for Linux [ARM CPU]..."
-        sudo curl -s -o $ADB "http://github.com/corbindavenport/nexus-tools/raw/master/bin/linux-arm-adb" -LOk
+        sudo curl -o $ADB "http://github.com/corbindavenport/nexus-tools/raw/master/bin/linux-arm-adb" -Lks
         echo "[INFO] Downloading Fastboot for Linux [ARM CPU]..."
-        sudo curl -s -o $FASTBOOT "http://github.com/corbindavenport/nexus-tools/raw/master/bin/linux-arm-fastboot" -LOk
+        sudo curl -o $FASTBOOT "http://github.com/corbindavenport/nexus-tools/raw/master/bin/linux-arm-fastboot" -Lks
     else
     	echo "[EROR] Your CPU platform could not be detected."
     	echo " "
@@ -83,7 +83,7 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then # Generic Linux
         if [ ! -d /etc/udev/rules.d/ ]; then
             sudo mkdir -p /etc/udev/rules.d/
         fi
-        sudo curl -s -o $UDEV "http://github.com/corbindavenport/nexus-tools/raw/master/udev.txt" -LOk
+        sudo curl -o $UDEV "http://github.com/corbindavenport/nexus-tools/raw/master/udev.txt" -Lks
         sudo chmod 644 $UDEV
         sudo chown root. $UDEV 2>/dev/null
         sudo service udev restart 2>/dev/null

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -21,7 +21,7 @@ UDEV="/etc/udev/rules.d/51-android.rules"
 
 echo "[INFO] Nexus Tools 2.3"
 echo "[INFO] Please enter sudo password for uninstall."
-sudo echo "[ OK ] Sudo access granted."
+sudo echo "[ OK ] Sudo access granted." || { echo "[ERROR] No sudo access."; exit 1; }
 
 # check for chrome os
 


### PR DESCRIPTION
In curl -O does "Write  output  to  a  local file named like the remote file we get." and -o "Write output to \<file\> instead of stdout." There is no sense in using both options.

In uninstall.sh sudo access should be checked as well as in install.sh.

In chown the (new?) syntax is \<chown owner:group\> rather than \<chown owner.group\>.
