### PR TITLE
Add a checker to see if bin folder already exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,6 +79,11 @@ if [ -f $FASTBOOT ]; then
     [ "$input" = "" ] && sudo rm $FASTBOOT || exit 1
 fi
 
+# check if bin folder is already created
+if [ ! -d /usr/local/bin/ ]; then
+    sudo mkdir -p /usr/local/bin/
+fi
+
 # detect operating system and install
 
 if [ "$OS" == "Darwin" ]; then # Mac OS X


### PR DESCRIPTION
I faced this trouble with a clean OS X El Capitan build because the folder bin was not created inside /usr/local, so when you tried to download and install ADB or Fastboot it failed. After creating it all the process runs perfectly with no errors.