### PR TITLE
Switch to https instead of http

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -21,7 +21,7 @@ ARCH=$(uname -m)
 
 XCODE=0
 
-BASEURL="http://github.com/corbindavenport/nexus-tools/raw/master"
+BASEURL="https://github.com/corbindavenport/nexus-tools/raw/master"
 
 _install() {
 	sudo curl -Lfks -o "$1" "$2" && echo "[INFO] Success." || { echo "[EROR] Download failed."; XCODE=1; }


### PR DESCRIPTION
This is a small change, but we should use https, since it´s a secured website, and the default system is already enabled to https in the website.